### PR TITLE
Fix clean up with absolute output folder

### DIFF
--- a/packages/renderer/server/render-video.ts
+++ b/packages/renderer/server/render-video.ts
@@ -338,7 +338,6 @@ async function cleanup(
     );
     cleanupFiles.push(
       path.join(
-        process.cwd(),
         outputFolderName,
         `${outputFileName}-${i}.${extensions[format]}`,
       ),
@@ -346,11 +345,10 @@ async function cleanup(
   }
 
   cleanupFiles.push(
-    path.join(process.cwd(), outputFolderName, `${outputFileName}-audio.wav`),
+    path.join(outputFolderName, `${outputFileName}-audio.wav`),
   );
   cleanupFiles.push(
     path.join(
-      process.cwd(),
       outputFolderName,
       `${outputFileName}-visuals.${extensions[format]}`,
     ),


### PR DESCRIPTION
when `renderVideo` with the absolute `outDir` folder, the path would be an issue in `cleanup` function.

it seems `process.cwd()` is unnecessary.